### PR TITLE
[WIP] Add support for 2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ lazy val noPublishSettings = Seq(
 
 import java.io.File
 
-def crossVersionSharedSources()  = Seq( 
+def crossVersionSharedSources()  = Seq(
  (unmanagedSourceDirectories in Compile) ++= { (unmanagedSourceDirectories in Compile ).value.map {
      dir:File => new File(dir.getPath + "_" + scalaBinaryVersion.value)}}
 )
@@ -96,8 +96,8 @@ lazy val scalaMacroDependencies: Seq[Setting[_]] = Seq(
       // in Scala 2.10, quasiquotes are provided by macro paradise
       case Some((2, 10)) =>
         Seq(
-          compilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full),
-              "org.scalamacros" %% "quasiquotes" % "2.1.0-M5" cross CrossVersion.binary
+          compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
+              "org.scalamacros" %% "quasiquotes" % "2.1.0" cross CrossVersion.binary
         )
     }
   }
@@ -107,4 +107,3 @@ credentials ++= (for {
   username <- Option(System.getenv().get("SONATYPE_USERNAME"))
   password <- Option(System.getenv().get("SONATYPE_PASSWORD"))
 } yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)).toSeq
-

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val buildSettings = Seq(
   name := "contextual",
   version := "0.14",
   scalacOptions ++= Seq("-deprecation", "-feature"),
-  crossScalaVersions := Seq("2.11.8", "2.12.1"),
+  crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.1"),
   scmInfo := Some(ScmInfo(url("https://github.com/propensive/contextual"),
     "scm:git:git@github.com:propensive/contextual.git"))
 )

--- a/core/src/main/scala-2.10/contextual/compat/package.scala
+++ b/core/src/main/scala-2.10/contextual/compat/package.scala
@@ -1,0 +1,5 @@
+package contextual
+
+package object compat {
+  type Context = scala.reflect.macros.Context
+}

--- a/core/src/main/scala-2.11/contextual/compat/package.scala
+++ b/core/src/main/scala-2.11/contextual/compat/package.scala
@@ -1,0 +1,5 @@
+package contextual
+
+package object compat {
+  type Context = scala.reflect.macros.blackbox.Context
+}

--- a/core/src/main/scala-2.11/contextual/compat/package.scala
+++ b/core/src/main/scala-2.11/contextual/compat/package.scala
@@ -1,5 +1,5 @@
 package contextual
 
 package object compat {
-  type Context = scala.reflect.macros.blackbox.Context
+  type Context = scala.reflect.macros.whitebox.Context
 }

--- a/core/src/main/scala-2.12/contextual/compat/package.scala
+++ b/core/src/main/scala-2.12/contextual/compat/package.scala
@@ -1,0 +1,5 @@
+package contextual
+
+package object compat {
+  type Context = scala.reflect.macros.blackbox.Context
+}

--- a/core/src/main/scala-2.12/contextual/compat/package.scala
+++ b/core/src/main/scala-2.12/contextual/compat/package.scala
@@ -1,5 +1,5 @@
 package contextual
 
 package object compat {
-  type Context = scala.reflect.macros.blackbox.Context
+  type Context = scala.reflect.macros.whitebox.Context
 }

--- a/core/src/main/scala/contextual/contextual.scala
+++ b/core/src/main/scala/contextual/contextual.scala
@@ -67,7 +67,7 @@ trait Interpolator extends Interpolator.Parts { interpolator =>
     val context: compat.Context = null
 
     /** The expressions that are substituted into the interpolated string. */
-    def expressions: Seq[context.Tree] = Nil
+    def expressions: Seq[context.Expr[Any]] = Nil
 
     lazy val universe: context.universe.type = context.universe
 
@@ -91,7 +91,7 @@ trait Interpolator extends Interpolator.Parts { interpolator =>
   /** The macro evaluator that defines what code will be generated for this `Interpolator`. The
     * default implementation constructs a new runtime `Contextual` object, and invokes the
     * `evaluate` method on the `Interpolator`. */
-  def evaluator(contexts: Seq[Ctx], contextual: Contextual[StaticPart]): contextual.context.Tree = {
+  def evaluator(contexts: Seq[Ctx], contextual: Contextual[StaticPart]): contextual.context.Expr[Any] = {
 
     val c: contextual.context.type = contextual.context
 

--- a/core/src/main/scala/contextual/macros.scala
+++ b/core/src/main/scala/contextual/macros.scala
@@ -1,12 +1,12 @@
 /* Contextual, version 0.14. Copyright 2016 Jon Pretty, Propensive Ltd.
  *
  * The primary distribution site is: http://co.ntextu.al/
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  * either express or implied. See the License for the specific language governing permissions
@@ -14,29 +14,28 @@
  */
 package contextual
 
-import scala.reflect._, macros.whitebox
-
 import language.experimental.macros
 
 /** Object containing the main macro providing Contextual's functionality. */
 object Macros {
   def contextual[C <: Context, I <: Interpolator { type Ctx = C }: c.WeakTypeTag]
-      (c: whitebox.Context)(exprs: c.Tree*): c.Tree = {
-    
+  (c: compat.Context)(exprs: c.Tree*): c.Tree = {
+  //(c: foobar.Context)(exprs: c.Tree*): c.Tree = {
+
     import c.universe.{Literal => AstLiteral, _}
-    
+
     /* Get the string literals from the constructed `StringContext`. */
     val astLiterals = c.prefix.tree match {
       case Select(Apply(_, List(Apply(_, lits))), _) => lits
     }
-    
+
     val literals = astLiterals.map { case AstLiteral(Constant(str: String)) => str }
-   
+
     /* Get the "context" types derived from each parameter. */
     val appliedParameters = c.macroApplication match {
       case Apply(_, params) => params
     }
-   
+
     /* Work out Java name of the class we want to instantiate. This is necessary because classes
      * defined within objects have the names of their parent objects encoded in their class
      * names, yet are presented in symbols in the standard "dotted" style, e.g.
@@ -49,13 +48,13 @@ object Macros {
     def getModule[M](tpe: Type): M = {
       val typeName = javaClassName(tpe.typeSymbol)
       val cls = Class.forName(s"$typeName$$")
-      
+
       /* It would be nice to avoid the unchecked pattern-match. */
       cls.getField("MODULE$").get(cls) match { case cls: M => cls }
     }
 
     val interpolatorName = javaClassName(weakTypeOf[I].typeSymbol)
-    
+
     /* Get an instance of the Interpolator class. */
     val interpolator = try getModule[I](weakTypeOf[I]) catch {
       case e: Exception => c.abort(c.enclosingPosition, e.toString)
@@ -70,7 +69,11 @@ object Macros {
         }
 
         val contextObjects = types.map { t =>
-          (getModule[C](t.typeArgs(0)), getModule[C](t.typeArgs(1)))
+          val args = t match {
+            case TypeRef(_, _, args) ⇒ args
+            case _                   ⇒ Nil
+          }
+          (getModule[C](args(0)), getModule[C](args(1)))
         }.toMap
 
         interpolator.Hole(idx, contextObjects)

--- a/core/src/main/scala/contextual/macros.scala
+++ b/core/src/main/scala/contextual/macros.scala
@@ -19,8 +19,7 @@ import language.experimental.macros
 /** Object containing the main macro providing Contextual's functionality. */
 object Macros {
   def contextual[C <: Context, I <: Interpolator { type Ctx = C }: c.WeakTypeTag]
-  (c: compat.Context)(exprs: c.Tree*): c.Tree = {
-  //(c: foobar.Context)(exprs: c.Tree*): c.Tree = {
+  (c: compat.Context)(exprs: c.Expr[Any]*): c.Expr[Any] = {
 
     import c.universe.{Literal => AstLiteral, _}
 


### PR DESCRIPTION
This (mostly) adds support for 2.10. Only one compilation problem remains:

```scala
error] /contribs/contextual/core/src/main/scala/contextual/contextual.scala:51: macro implementation has incompatible shape:
[error]  required: (c: scala.reflect.macros.Context)(exprs: c.Expr[contextual.Interpolator.Embedded[Prefix.this.interpolator.Inputs,Prefix.this.interpolator.type]]*): c.Expr[Any]
[error]  found   : (c: contextual.compat.Context)(exprs: c.Tree*): c.Tree
[error] type mismatch for parameter exprs: c.Expr[contextual.Interpolator.Embedded[Prefix.this.interpolator.Inputs,Prefix.this.interpolator.type]]* does not conform to c.universe.Tree*
[error]       macro Macros.contextual[C, P]
```

I'm making a PR as is following our [gitter conversation](https://gitter.im/propensive/contextual?at=5851cfcafb22792b3b64e9c6).