### PR TITLE
POC adding scala and scalac interpolators

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ lazy val examples = project
   .settings(buildSettings: _*)
   .settings(publishSettings: _*)
   .settings(moduleName := "contextual-examples")
+  .settings(libraryDependencies += "com.twitter" %% "util-eval" % "6.40.0")
   .settings(quasiQuotesDependencies)
   .dependsOn(core)
 

--- a/examples/src/main/scala/contextual/examples/scala2.scala
+++ b/examples/src/main/scala/contextual/examples/scala2.scala
@@ -1,0 +1,33 @@
+package contextual.examples
+
+import com.twitter.util.Eval
+import contextual.{Interpolator, Prefix}
+
+object scala2 {
+
+  object Scala2Parser extends Interpolator {
+
+    def contextualize(interpolation: StaticInterpolation): Seq[ContextType] = {
+
+      interpolation.parts.foreach {
+        case lit@Literal(_, string) =>
+          try {
+            new Eval().apply[Any](string)
+          } catch {
+            case e: Eval.CompilerException =>
+              interpolation.abort(lit, 0, e.getMessage)
+          }
+        case hole@Hole(_, _) =>
+          interpolation.abort(hole, "substitution is not supported")
+      }
+
+      Nil
+    }
+
+    def evaluate[A](interpolation: RuntimeInterpolation): A =
+      new Eval().apply(interpolation.parts.mkString)
+  }
+
+  implicit class Scala2StringContext(sc: StringContext) { val scala = Prefix(Scala2Parser, sc) }
+
+}

--- a/examples/src/main/scala/contextual/examples/scalac.scala
+++ b/examples/src/main/scala/contextual/examples/scalac.scala
@@ -1,0 +1,39 @@
+package contextual.examples
+
+import com.twitter.util.Eval
+import contextual.{Interpolator, Prefix}
+
+object scalac {
+
+  object ScalacParser extends Interpolator {
+
+    def contextualize(interpolation: StaticInterpolation): Seq[ContextType] = {
+
+      interpolation.parts.foreach {
+        case lit@Literal(_, string) =>
+          try {
+            new Eval().compile(string)
+          } catch {
+            case e: Eval.CompilerException =>
+              interpolation.abort(lit, 0, e.getMessage)
+          }
+        case hole@Hole(_, _) =>
+          interpolation.abort(hole, "substitution is not supported")
+      }
+
+      Nil
+    }
+
+    def evaluate(interpolation: RuntimeInterpolation): Context = {
+      val eval = new Eval()
+      eval.compile(interpolation.parts.mkString)
+      new Context(eval)
+    }
+  }
+
+  implicit class ScalacStringContext(sc: StringContext) { val scalac = Prefix(ScalacParser, sc) }
+
+  class Context(eval: Eval) {
+    def apply[A](s: String) = eval.inPlace[A](s)
+  }
+}

--- a/tests/src/main/scala/contextual/examples/tests.scala
+++ b/tests/src/main/scala/contextual/examples/tests.scala
@@ -22,10 +22,24 @@ object Testing {
 
     import contextual.examples._
     import shell._
+    import scala2._
+    import scalac._
 
     sh"foo bar $str baz"
     sh"""a b c d ${"e"} ${"f"}"""
 
+    println(scala"21 + 21") // 42
+
+    val ctx: Context = scalac"object D { def apply(i: Int) = i * 2 }"
+    println(ctx("D(21)")) // 42
+
+    // does not compile
+    // tests.scala:38: Compiler exception error: line 1: not found: value x
+    // scala"x"
+
+    // does not compile
+    // tests.scala:42: Compiler exception error: line -1: expected class or object definition
+    // scalac"x"
   }
 }
 


### PR DESCRIPTION
Playing around a bit with a `scala` and `scalac` interpolator, allowing e.g.:

```
scala"21 + 21"
scalac"object D { def apply(i: Int) = i * 2 }"
```
(see `tests.scala` for a bit more detail)

Not necessarily meant to merge in, happy to discuss alternatives/improvements, e.g.:

* get rid of dependency `com.twitter.util-eval` (this was just the shortest route I knew to compile and evaluate scala)
* other location (maybe even outside contextual?)