### PR TITLE
update sbt to 13.15 to get rid of version conflict warnings

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.15


### PR DESCRIPTION
With sbt 13.15 the current warnings about version differences disappear

`[warn] Binary version (2.11) for dependency org.scala-lang#scala-library;2.11.8
[warn] 	in com.propensive#contextual_2.12;1.0.1 differs from Scala binary version in project (2.12).
[warn] Binary version (2.11) for dependency org.scala-lang#scala-library;2.11.8
[warn] 	in com.propensive#contextual-examples_2.12;1.0.1 differs from Scala binary version in project (2.12).
`