### PR TITLE
Introduction of HoleTransitions

### DIFF
--- a/core/src/main/scala/contextual/interpolator.scala
+++ b/core/src/main/scala/contextual/interpolator.scala
@@ -41,9 +41,7 @@ trait Interpolator { interpolator =>
     */
   type Output
 
-  object HoleTransition {
-    implicit def genericHoleTransition[InputType <: Input, SameContext <: ContextType]: HoleTransition[InputType, SameContext] { type Out = SameContext } = new HoleTransition[InputType, SameContext]() { type Out = SameContext }
-  }
+  implicit def genericHoleTransition[InputType <: Input, SameContext <: ContextType]: HoleTransition[InputType, SameContext] { type Out = SameContext } = new HoleTransition[InputType, SameContext]() { type Out = SameContext }
 
   /** Class representing, at the type-level, the transition from the Context prior to the
     * substitution, [[PriorContext]], to a different context, [[Out]], after the

--- a/examples/src/main/scala/contextual/examples/sh.scala
+++ b/examples/src/main/scala/contextual/examples/sh.scala
@@ -28,6 +28,9 @@ object shell {
   case object InUnquotedParam extends ShellContext
   case object NewParam extends ShellContext
 
+  implicit val newParamToUnquote =
+    ShellInterpolator.holeTransition(NewParam, InUnquotedParam)
+
   object ShellInterpolator extends Interpolator {
     type ContextType = ShellContext
     type Input = String
@@ -89,10 +92,10 @@ object shell {
     }
 
   implicit val embedStrings = ShellInterpolator.embed[String](
-    Case(NewParam, InUnquotedParam) { s => '"'+s.replaceAll("\\\"", "\\\\\"")+'"' },
-    Case(InUnquotedParam, InUnquotedParam) { s => '"'+s.replaceAll("\\\"", "\\\\\"")+'"' },
-    Case(InSingleQuotes, InSingleQuotes) { s => s.replaceAll("'", """'"'"'""") },
-    Case(InDoubleQuotes, InDoubleQuotes) { s => s.replaceAll("\\\"", "\\\\\"") }
+    on(NewParam) { s => '"'+s.replaceAll("\\\"", "\\\\\"")+'"' },
+    on(InUnquotedParam) { s => '"'+s.replaceAll("\\\"", "\\\\\"")+'"' },
+    on(InSingleQuotes) { s => s.replaceAll("'", """'"'"'""") },
+    on(InDoubleQuotes) { s => s.replaceAll("\\\"", "\\\\\"") }
   )
   
   implicit class ShellStringContext(sc: StringContext) {


### PR DESCRIPTION
This separates the logic for parsing across substitutions (holes) from
the logic surrounding how certain types should be substituted.

In practical terms, this means that users extending an interpolator by
providing their own embeddings no longer need to describe how the
parsing context changes *across* a hole by specifying both the "before"
and "after" contexts. Additionally, the `Case(...)` syntax has been
changed to `on(...)`, so an embedding can now be written as:

```scala
MyInterpolator.embed[SomeType](
  on(Context1) { a => ... },
  on(Context2) { a => ... },
  ...
)
```

This also eliminates the possibility that a user providing their own
embedding can interfere with parsing, so closes a potential safety hole
where an end-user-defined embedding can result in the acceptance of
invalid content.