### PR TITLE
Ensure that `Output` type is specified for hex and bin examples

### DIFF
--- a/examples/src/main/scala/contextual/examples/binary.scala
+++ b/examples/src/main/scala/contextual/examples/binary.scala
@@ -20,6 +20,8 @@ object binary {
 
   object BinParser extends Interpolator {
 
+    type Output = Array[Byte]
+
     def contextualize(interpolation: StaticInterpolation) = Nil
 
     override def evaluator(contexts: Seq[ContextType], interpolation: StaticInterpolation):

--- a/examples/src/main/scala/contextual/examples/hex.scala
+++ b/examples/src/main/scala/contextual/examples/hex.scala
@@ -20,6 +20,8 @@ object hex {
 
   object HexParser extends Interpolator {
 
+    type Output = Array[Byte]
+
     def contextualize(interpolation: StaticInterpolation): Seq[ContextType] = Nil
 
     override def evaluator(contexts: Seq[ContextType], interpolation: StaticInterpolation):


### PR DESCRIPTION
Fixes #16. 