### PR TITLE
Add slightly more complete unit tests

### DIFF
--- a/tests/shared/src/main/scala/contextual/examples/InterpolatorTest.scala
+++ b/tests/shared/src/main/scala/contextual/examples/InterpolatorTest.scala
@@ -1,0 +1,43 @@
+package contextual.examples
+
+import scala.util.{Failure, Success, Try}
+
+import contextual.Interpolator
+import contextual.examples.InterpolatorTest.{BadMatch, BadParse, Successful, TestResult}
+
+trait InterpolatorTest[I <: Interpolator] {
+  type Example = (() => I#Output, I#Output)
+  def testName: String = this.getClass.getSimpleName
+  def interpolator: I
+  def examples: List[Example]
+  def eq(x: I#Output, y: I#Output): Boolean = x == y
+
+  def testExamples: (List[TestResult], List[TestResult]) = {
+    examples.map { case (thunk, expected) =>
+      Try(thunk()) match {
+        case Success(result) if eq(result, expected) => Successful
+        case Success(result) => BadMatch(expected, result)
+        case Failure(_) => BadParse(expected)
+      }
+    }.partition {
+      case Successful => true
+      case _ => false
+    }
+  }
+
+  def runTests(): Unit = {
+    println(s"Running tests for $testName")
+    val (succ, fail) = testExamples
+    fail.foreach { f =>
+      println(s"Test Failed: $f")
+    }
+    println(s"Results: ${succ.size} successes and ${fail.size} failures")
+  }
+}
+
+object InterpolatorTest {
+  sealed trait TestResult
+  case object Successful extends TestResult
+  case class BadParse[T](expected: T) extends TestResult
+  case class BadMatch[T](expected: T, result: T) extends TestResult
+}

--- a/tests/shared/src/main/scala/contextual/examples/TestingApp.scala
+++ b/tests/shared/src/main/scala/contextual/examples/TestingApp.scala
@@ -12,11 +12,9 @@
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package contextual.tests
-
-import contextual.examples.Tests
+package contextual.examples
 
 object TestingApp extends App {
-  Tests.testEmailAndShell()
+  Tests.runTests()
 }
 

--- a/tests/shared/src/main/scala/contextual/examples/Tests.scala
+++ b/tests/shared/src/main/scala/contextual/examples/Tests.scala
@@ -1,18 +1,68 @@
 package contextual.examples
 
-/**
-  * Created by marius on 03.05.17.
-  */
+import contextual.examples._
+import shell._
+import email._
+import binary._
+import hex._
+
 object Tests {
-  import contextual.examples._
-  import shell._
-  import email._
 
-  def testEmailAndShell() = {
-    val res = email"aaa@ddd.com"
-    val res2 = sh"""a b c d ${"e"} ${"f"}"""
+  object BinaryTest extends InterpolatorTest[BinParser.type] {
+    def interpolator = BinParser
 
-    println(res.address)
-    println(res2.args)
+    override def eq(x: Array[Byte], y: Array[Byte]): Boolean =
+      x.toList == y.toList
+
+    def examples =
+      List(
+        (() => bin"00000000", Array(0.toByte)),
+        (() => bin"11111111", Array(255.toByte)),
+        (() => bin"00001111", Array(15.toByte)),
+        (() => bin"01010101", Array(85.toByte)),
+        (() => bin"0101010100001111", Array(85.toByte, 15.toByte))
+      )
   }
+
+  object EmailTest extends InterpolatorTest[EmailParser.type] {
+    def interpolator = EmailParser
+
+    def examples =
+      List(
+        (() => email"aaa@ddd.com", EmailAddress("aaa@ddd.com")),
+        (() => email"complex+test@dep.company.eu", EmailAddress("complex+test@dep.company.eu"))
+      )
+  }
+
+  object HexTest extends InterpolatorTest[HexParser.type] {
+    def interpolator = HexParser
+
+    override def eq(x: Array[Byte], y: Array[Byte]): Boolean =
+      x.toList == y.toList
+
+    def examples =
+      List(
+        (() => hex"00", Array(0.toByte)),
+        (() => hex"ff", Array(255.toByte)),
+        (() => hex"0f", Array(15.toByte)),
+        (() => hex"55", Array(85.toByte)),
+        (() => hex"550f", Array(85.toByte, 15.toByte))
+      )
+  }
+
+  object ShTest extends InterpolatorTest[ShellInterpolator.type] {
+    def interpolator = ShellInterpolator
+
+    override def eq(x: Process, y: Process): Boolean =
+      x.args.filter(_.nonEmpty).toList == y.args.filter(_.nonEmpty).toList
+
+    def examples =
+      List(
+        (() => sh"""a b c d ${"e"} ${"f"}""", Process("a","b","c","d","e","f"))
+      )
+  }
+
+  val tests: List[InterpolatorTest[_]] = List(BinaryTest, EmailTest, HexTest, ShTest)
+
+  def runTests() = tests.foreach(_.runTests())
 }


### PR DESCRIPTION
Adds more unit tests and some automatic checks.

Unfortunately, since most of the work is done at compile time, it's really hard to create examples that must fail. Some unit test frameworks such as specs2 have some support for compile-time tests, but I'm not sure if they work with code generated by macros.