### PR TITLE
Add support for holes in binary example

### DIFF
--- a/tests/shared/src/main/scala/contextual/examples/TestingApp.scala
+++ b/tests/shared/src/main/scala/contextual/examples/TestingApp.scala
@@ -18,5 +18,6 @@ import contextual.examples.Tests
 
 object TestingApp extends App {
   Tests.testEmailAndShell()
+  Tests.testBinary()
 }
 

--- a/tests/shared/src/main/scala/contextual/examples/Tests.scala
+++ b/tests/shared/src/main/scala/contextual/examples/Tests.scala
@@ -7,6 +7,7 @@ object Tests {
   import contextual.examples._
   import shell._
   import email._
+  import binary._
 
   def testEmailAndShell() = {
     val res = email"aaa@ddd.com"
@@ -14,5 +15,14 @@ object Tests {
 
     println(res.address)
     println(res2.args)
+  }
+
+  def testBinary() = {
+    val v1 = bin"011000010110000101100010"
+    val b = "01100010"
+    val v2 = bin"0110000101100001$b"
+
+    println(v1.map(_.toChar).mkString)
+    println(v2.map(_.toChar).mkString)
   }
 }


### PR DESCRIPTION
This PR adds support for holes in the binary example. This was done in scope of Scala Swarm's Scala Center Hackathon.

The implemented strategy tries to check as much as possible during compile time and only falls back to runtime checks when dynamic parts are used.

I was unable to avoid adding an `Embedder` typeclass, even though it doesn't seem necessary. Is it possible to avoid it?