### PR TITLE
Catch `ClassNotFoundException` and print a nice message.

### DIFF
--- a/core/src/main/scala/contextual/macros.scala
+++ b/core/src/main/scala/contextual/macros.scala
@@ -56,7 +56,7 @@ class Macros(val c: whitebox.Context) {
         cls.getField("MODULE$").get(cls).asInstanceOf[M]
       } catch {
         case e: ClassNotFoundException =>
-          c.abort(c.enclosingPosition, s"""Class "${typeName}" could not be found. This usually means you are trying to use an interpolator in the same compilation unit as the one in which you defined it. Please try moving interpolator definitions to a separate (sub)project. Details: https://github.com/propensive/contextual/issues/4""")
+          c.abort(c.enclosingPosition, s"""Class "${typeName}" could not be found. This usually means you are trying to use an interpolator in the same compilation unit as the one in which you defined it. Please try compiling interpolators first, separately from the code using them.""")
       }
     }
 

--- a/core/src/main/scala/contextual/macros.scala
+++ b/core/src/main/scala/contextual/macros.scala
@@ -50,9 +50,14 @@ class Macros(val c: whitebox.Context) {
 
     def getModule[M](tpe: Type): M = {
       val typeName = javaClassName(tpe.typeSymbol)
-      val cls = Class.forName(s"$typeName$$")
 
-      cls.getField("MODULE$").get(cls).asInstanceOf[M]
+      try {
+        val cls = Class.forName(s"$typeName$$")
+        cls.getField("MODULE$").get(cls).asInstanceOf[M]
+      } catch {
+        case e: ClassNotFoundException =>
+          c.abort(c.enclosingPosition, s"""Class "${cls}" could not be found. This usually means you are trying to use an interpolator in the same compilation unit as the one in which you defined it. Please try moving interpolator definitions to a separate (sub)project. Details: https://github.com/propensive/contextual/issues/4""")
+      }
     }
 
     /* Get an instance of the Interpolator class. */

--- a/core/src/main/scala/contextual/macros.scala
+++ b/core/src/main/scala/contextual/macros.scala
@@ -56,7 +56,7 @@ class Macros(val c: whitebox.Context) {
         cls.getField("MODULE$").get(cls).asInstanceOf[M]
       } catch {
         case e: ClassNotFoundException =>
-          c.abort(c.enclosingPosition, s"""Class "${cls}" could not be found. This usually means you are trying to use an interpolator in the same compilation unit as the one in which you defined it. Please try moving interpolator definitions to a separate (sub)project. Details: https://github.com/propensive/contextual/issues/4""")
+          c.abort(c.enclosingPosition, s"""Class "${typeName}" could not be found. This usually means you are trying to use an interpolator in the same compilation unit as the one in which you defined it. Please try moving interpolator definitions to a separate (sub)project. Details: https://github.com/propensive/contextual/issues/4""")
       }
     }
 


### PR DESCRIPTION
People trying out Contextual often run into a `ClassNotFoundException` because they define an interpolator and use it in the same compilation unit. This PR tries to help them by providing a nice, human-friendly message. Partially solves #4.