### PR TITLE
Add support for implicit parameters for wrapped StringContext

### DIFF
--- a/core/src/main/scala/contextual/macros.scala
+++ b/core/src/main/scala/contextual/macros.scala
@@ -27,7 +27,8 @@ class Macros(val c: whitebox.Context) {
 
     /* Get the string literals from the constructed `StringContext`. */
     val astLiterals = c.prefix.tree match {
-      case Select(Apply(_, List(Apply(_, lits))), _) => lits
+      case Select(Apply(_, List(Apply(_, lits))), _)           => lits
+      case Select(Apply(Apply(_, List(Apply(_, lits))), _), _) => lits
     }
 
     val stringLiterals: Seq[String] = astLiterals.map {


### PR DESCRIPTION
Fixes this error
```
<console>:16: error: exception during macro expansion:
scala.MatchError: contextual.examples.int.IntStringContext(scala.StringContext.apply("1"))(str).int (of class scala.reflect.internal.Trees$Select)
	at contextual.Macros.contextual(macros.scala:30)

       int"1"
```
Example of StringContext wrapper.
```
implicit class IntStringContext(sc: StringContext)(implicit str: String) {
  final val int = Prefix(IntParser, sc)
}
```