### PR TITLE
fix outdated url to docs website

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ interpolators—prefixes for string literals which determine how they should be
 interpreted—and to specify what should happen at runtime and compile-time,
 writing very ordinary user code: no macros. 
 
-Please see the [co.ntextu.al](http://co.ntextu.al/) website for more information.
+Please see the [website](https://propensive.com/opensource/contextual) for more information.
 
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ lazy val buildSettings = Seq(
 )
 
 lazy val publishSettings = Seq(
-  homepage := Some(url("http://co.ntextu.al/")),
+  homepage := Some(url("https://propensive.com/opensource/contextual")),
   licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
   autoAPIMappings := true,
   publishMavenStyle := true,

--- a/core/src/main/scala/contextual/context.scala
+++ b/core/src/main/scala/contextual/context.scala
@@ -1,6 +1,6 @@
 /* Contextual, version 1.1.0. Copyright 2018 Jon Pretty, Propensive Ltd.
  *
- * The primary distribution site is: http://co.ntextu.al/
+ * The primary distribution site is: https://propensive.com/opensource/contextual/
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/scala/contextual/interpolator.scala
+++ b/core/src/main/scala/contextual/interpolator.scala
@@ -1,6 +1,6 @@
 /* Contextual, version 1.1.0. Copyright 2018 Jon Pretty, Propensive Ltd.
  *
- * The primary distribution site is: http://co.ntextu.al/
+ * The primary distribution site is: https://propensive.com/opensource/contextual/
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/scala/contextual/macros.scala
+++ b/core/src/main/scala/contextual/macros.scala
@@ -1,6 +1,6 @@
 /* Contextual, version 1.1.0. Copyright 2018 Jon Pretty, Propensive Ltd.
  *
- * The primary distribution site is: http://co.ntextu.al/
+ * The primary distribution site is: https://propensive.com/opensource/contextual/
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/scala/contextual/prefix.scala
+++ b/core/src/main/scala/contextual/prefix.scala
@@ -1,6 +1,6 @@
 /* Contextual, version 1.1.0. Copyright 2018 Jon Pretty, Propensive Ltd.
  *
- * The primary distribution site is: http://co.ntextu.al/
+ * The primary distribution site is: https://propensive.com/opensource/contextual/
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/data/src/main/scala/contextual/data/binary.scala
+++ b/data/src/main/scala/contextual/data/binary.scala
@@ -1,6 +1,6 @@
 /* Contextual, version 1.1.0. Copyright 2018 Jon Pretty, Propensive Ltd.
  *
- * The primary distribution site is: http://co.ntextu.al/
+ * The primary distribution site is: https://propensive.com/opensource/contextual/
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/data/src/main/scala/contextual/data/email.scala
+++ b/data/src/main/scala/contextual/data/email.scala
@@ -1,6 +1,6 @@
 /* Contextual, version 1.1.0. Copyright 2018 Jon Pretty, Propensive Ltd.
  *
- * The primary distribution site is: http://co.ntextu.al/
+ * The primary distribution site is: https://propensive.com/opensource/contextual/
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/data/src/main/scala/contextual/data/fqt.scala
+++ b/data/src/main/scala/contextual/data/fqt.scala
@@ -1,6 +1,6 @@
 /* Contextual, version 1.1.0. Copyright 2018 Jon Pretty, Propensive Ltd.
  *
- * The primary distribution site is: http://co.ntextu.al/
+ * The primary distribution site is: https://propensive.com/opensource/contextual/
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/data/src/main/scala/contextual/data/hex.scala
+++ b/data/src/main/scala/contextual/data/hex.scala
@@ -1,6 +1,6 @@
 /* Contextual, version 1.1.0. Copyright 2018 Jon Pretty, Propensive Ltd.
  *
- * The primary distribution site is: http://co.ntextu.al/
+ * The primary distribution site is: https://propensive.com/opensource/contextual/
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/data/src/main/scala/contextual/data/regex.scala
+++ b/data/src/main/scala/contextual/data/regex.scala
@@ -1,6 +1,6 @@
 /* Contextual, version 1.1.0. Copyright 2018 Jon Pretty, Propensive Ltd.
  *
- * The primary distribution site is: http://co.ntextu.al/
+ * The primary distribution site is: https://propensive.com/opensource/contextual/
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/data/src/main/scala/contextual/data/scalac.scala
+++ b/data/src/main/scala/contextual/data/scalac.scala
@@ -1,6 +1,6 @@
 /* Contextual, version 1.1.0. Copyright 2018 Jon Pretty, Propensive Ltd.
  *
- * The primary distribution site is: http://co.ntextu.al/
+ * The primary distribution site is: https://propensive.com/opensource/contextual/
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/data/src/main/scala/contextual/data/sh.scala
+++ b/data/src/main/scala/contextual/data/sh.scala
@@ -1,6 +1,6 @@
 /* Contextual, version 1.1.0. Copyright 2018 Jon Pretty, Propensive Ltd.
  *
- * The primary distribution site is: http://co.ntextu.al/
+ * The primary distribution site is: https://propensive.com/opensource/contextual/
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/data/src/main/scala/contextual/data/txt.scala
+++ b/data/src/main/scala/contextual/data/txt.scala
@@ -1,6 +1,6 @@
 /* Contextual, version 1.1.0. Copyright 2018 Jon Pretty, Propensive Ltd.
  *
- * The primary distribution site is: http://co.ntextu.al/
+ * The primary distribution site is: https://propensive.com/opensource/contextual/
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/data/src/main/scala/contextual/data/xpath.scala
+++ b/data/src/main/scala/contextual/data/xpath.scala
@@ -1,6 +1,6 @@
 /* Contextual, version 1.1.0. Copyright 2018 Jon Pretty, Propensive Ltd.
  *
- * The primary distribution site is: http://co.ntextu.al/
+ * The primary distribution site is: https://propensive.com/opensource/contextual/
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
README's website URL is outdated. Fortunately one in repo description is up to date so I was able to find it.