### PR TITLE
Addressing 'macro has not been expanded' error Scala 2.13.0 or newer

### DIFF
--- a/core/shared/src/main/scala/contextual/interpolator.scala
+++ b/core/shared/src/main/scala/contextual/interpolator.scala
@@ -220,8 +220,8 @@ trait Interpolator { interpolator =>
 
     q"""${interpolation.interpolatorTerm}.evaluate(
       new ${interpolation.interpolatorTerm}.RuntimeInterpolation(
-        _root_.scala.collection.Seq(..${interpolation.literals}),
-        _root_.scala.collection.Seq(..$substitutions)
+        _root_.scala.collection.immutable.Seq(..${interpolation.literals}),
+        _root_.scala.collection.immutable.Seq(..$substitutions)
       )
     )"""
   }

--- a/core/shared/src/main/scala/contextual/prefix.scala
+++ b/core/shared/src/main/scala/contextual/prefix.scala
@@ -35,8 +35,8 @@ object Prefix {
     * @return a new instance of a [[Prefix]]
     */
   def apply(interpolator: Interpolator, stringContext: StringContext):
-      Prefix[interpolator.Output, interpolator.ContextType, interpolator.type] =
-    new Prefix[interpolator.Output, interpolator.ContextType, interpolator.type](interpolator, stringContext.parts)
+      Prefix[interpolator.Input, interpolator.Output, interpolator.ContextType, interpolator.type] =
+    new Prefix[interpolator.Input, interpolator.Output, interpolator.ContextType, interpolator.type](stringContext.parts)
 
 }
 
@@ -44,15 +44,14 @@ object Prefix {
   * typically using an implicit class. It has only a single method, [[apply]], with a signature
   * that's appropriate for fitting the shape of a desugared interpolated string application.
   *
-  * @param interpolator the [[Interpolator]] object to bind to this prefix
   * @param parts a sequence of the literal parts of the interpolated string, taken from the
   * `parts` value of the [[scala.StringContext]]
   * @tparam PrefixContextType the context inferred from `interpolator`'s type member
   * @tparam InterpolatorType the singleton type of the [[Interpolator]]
   */
-final class Prefix[OutputType, PrefixContextType <: Context, InterpolatorType <: Interpolator {
+final class Prefix[InputType, OutputType, PrefixContextType <: Context, InterpolatorType <: Interpolator {
     type ContextType = PrefixContextType; type Output = OutputType }]
-    (interpolator: InterpolatorType, parts: Seq[String]) {
+    (parts: Seq[String]) {
 
   /** The [[apply]] method is typically invoked as a result of the desugaring of a
     * [[scala.StringContext]] during parsing in Scalac. The method signature takes multiple
@@ -65,6 +64,6 @@ final class Prefix[OutputType, PrefixContextType <: Context, InterpolatorType <:
     *
     * @param expressions a sequence of expressions corresponding to each substitution
     * @return the evaluated result of the [[contextual]] macro */
-  def apply(expressions: Interpolator.Embedded[interpolator.Input, interpolator.type]*):
+  def apply(expressions: Interpolator.Embedded[InputType, InterpolatorType]*):
       OutputType = macro Macros.contextual[PrefixContextType, InterpolatorType]
 }


### PR DESCRIPTION
It looks like on Scala 2.13.0 or newer version, contextual does not work and simply throws "macro has not been expanded" error when trying to use a defined interpolator. 

I narrowed it down to the apply function in the Prefix class that references "interpolator.Input" and "interpolator.type"on the provided interpolator. I do not fully understand the problem, but I tried to fix this issue by avoiding passing the interpolator as a parameter to the default constructor and instead passing the needed information via type parameters. So I added the "InputType" as a type parameter to the Prefix class. The "type" is already passed as a type parameter "InterpolatorType", so I simply changed the "interpolator.type" to "InterpolatorType". This seems to fix the problem.

Additionally, Scala 2.13.1 was complaining about incompatible Seq types, as it expects an immutable sequence, so I changed the interpolator code to use "__root__.scala.collection.immutable.Seq".

Fixes #54 